### PR TITLE
Progress bar

### DIFF
--- a/templates/check-out-what-youve-learned.html
+++ b/templates/check-out-what-youve-learned.html
@@ -5,7 +5,7 @@ s<section class="container check-out-what-youve-learned">
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/feelings.html
+++ b/templates/feelings.html
@@ -7,7 +7,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
     
     <div class="panel s0">

--- a/templates/i-am-worth-it.html
+++ b/templates/i-am-worth-it.html
@@ -6,7 +6,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
     <h3>My WORTH Badge of Honor</h3>
 

--- a/templates/my-commitment-to-me.html
+++ b/templates/my-commitment-to-me.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/myth-fact.html
+++ b/templates/myth-fact.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/popping-our-problems.html
+++ b/templates/popping-our-problems.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
     <div class="panel s0">
         <p>

--- a/templates/practicing-negotiation-1.html
+++ b/templates/practicing-negotiation-1.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/practicing-pop.html
+++ b/templates/practicing-pop.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
     <div class="panel s0">
         <p>

--- a/templates/protective-behaviors.html
+++ b/templates/protective-behaviors.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/reflect-amanda.html
+++ b/templates/reflect-amanda.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/reflect-charlene.html
+++ b/templates/reflect-charlene.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
     <div class="panel s0">
         <p>

--- a/templates/reflect-mia.html
+++ b/templates/reflect-mia.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/reflect-rasheeda.html
+++ b/templates/reflect-rasheeda.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/reflect-sofia.html
+++ b/templates/reflect-sofia.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/safety-plan-4.html
+++ b/templates/safety-plan-4.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/safety.html
+++ b/templates/safety.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
     <h3>Safety Planning</h3>
 

--- a/templates/self-talk-4.html
+++ b/templates/self-talk-4.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/self-talk.html
+++ b/templates/self-talk.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/sofias-trauma.html
+++ b/templates/sofias-trauma.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/ssnm.html
+++ b/templates/ssnm.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/things-i-am-proud-of.html
+++ b/templates/things-i-am-proud-of.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
     <h3>{% TITLE %}</h3>
 

--- a/templates/what-did-we-learn-2.html
+++ b/templates/what-did-we-learn-2.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/what-did-we-learn-3.html
+++ b/templates/what-did-we-learn-3.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/templates/what-did-we-learn-4.html
+++ b/templates/what-did-we-learn-4.html
@@ -5,7 +5,7 @@
 
     <div class="progress">
         <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar"
-             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">Activity Progess</div>
+             aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
     </div>
 
     <div class="panel s0">

--- a/worthapp/css/worth.css
+++ b/worthapp/css/worth.css
@@ -218,7 +218,7 @@ ol.toc li li {font-weight: normal;}
 }
 
 .progress {background-color: #fafafa; margin-top: 1em;}
-.progress-bar {height: 1.5em; padding: .5em;}
+.progress-bar {height: 1.5em; padding: .5em 0em;}
 
 .alert p {font-size: 1.5em;}
 

--- a/worthapp/index.html
+++ b/worthapp/index.html
@@ -1422,7 +1422,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -1516,7 +1515,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -1609,7 +1607,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -1852,7 +1849,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -2204,7 +2200,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <h3>
@@ -2419,7 +2414,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -2513,7 +2507,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -2598,7 +2591,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -3580,7 +3572,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -3823,7 +3814,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -4130,7 +4120,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -4223,7 +4212,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -4382,7 +4370,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -4711,7 +4698,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -4945,7 +4931,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -5424,7 +5409,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -5712,7 +5696,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -6244,7 +6227,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -6679,7 +6661,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -7294,7 +7275,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -7548,7 +7528,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <h3>
@@ -7723,7 +7702,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -8223,7 +8201,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -8505,7 +8482,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -9071,7 +9047,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -9515,7 +9490,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -9783,7 +9757,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -10206,7 +10179,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -10460,7 +10432,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <h3>
@@ -10635,7 +10606,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -11068,7 +11038,6 @@
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -11208,7 +11177,6 @@ s
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <div class="panel s0">
@@ -12113,7 +12081,6 @@ s
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <h3>
@@ -12481,7 +12448,6 @@ s
  </h2>
  <div class="progress">
   <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="progress-bar" role="progressbar">
-   Activity Progess
   </div>
  </div>
  <h3>


### PR DESCRIPTION
Remove 'Activity Progress' text from bar

Fix bug in progress bar: Horizontal padding on .progress-bar was causing an inacurate
representation of progress through the given section.