### PR TITLE
initActivityPanels: Resolve scoping issue for loop iterator

### DIFF
--- a/worthapp/js/src/common.js
+++ b/worthapp/js/src/common.js
@@ -30,6 +30,18 @@ var advanceToPanel = function($container, i, total) {
     pauseVideos($container);
 };
 
+var bindActivityButtons = function($container, idx, total) {
+    $container.find('button.s' + idx).click(function(e) {
+        e.preventDefault();
+
+        // Only advance the panel of the activity where this
+        // button was clicked.
+        var $myContainer = $(this).closest('.container');
+
+        advanceToPanel($myContainer, idx, total);
+    });
+};
+
 /**
  * Sets up the panel advancement behavior for the given activity
  * container.
@@ -38,14 +50,6 @@ var initActivityPanels = function($container) {
     var total = $container.first().find('.panel').length - 1;
 
     for (var i = 0; i <= total; i++) {
-        $container.find('button.s' + i).click(function(e) {
-            e.preventDefault();
-
-            // Only advance the panel of the activity where this
-            // button was clicked.
-            var $myContainer = $(this).closest('.container');
-
-            advanceToPanel($myContainer, i, total);
-        });
+        bindActivityButtons($container, i, total);
     }
 };


### PR DESCRIPTION
The let	statement declares a block scope local variable.
Previously, the loop iterator (i) was not visible within the bound click function.
Changing the declaration of i to var opened up the scope to allow the iterator
to be seen incorrectly within the bound click function. Updating to create a new
scope for the iterator.