### PR TITLE
Remove readyVideos()

### DIFF
--- a/worthapp/js/src/common.js
+++ b/worthapp/js/src/common.js
@@ -1,21 +1,11 @@
 /* global $ */
 /* eslint-env es6 */
 /* exported updateProgressBar, advanceToPanel, initActivityPanels */
-/* exported pauseVideos, readyVideos, isFormComplete, onClickGetAnswers */
+/* exported pauseVideos, isFormComplete, onClickGetAnswers */
 
 /*
  * Stop playback of any playing videos in the given container.
  */
-
-var readyVideos = function($container) {
-    if ($container) {
-        $.each($container.find('video'), function() {
-            if (this.readyState !== 4) {
-                this.load(); // reload
-            }
-        });
-    }
-};
 
 var pauseVideos = function($container) {
     if ($container) {

--- a/worthapp/js/src/swiper-setup.js
+++ b/worthapp/js/src/swiper-setup.js
@@ -1,5 +1,5 @@
 /* eslint-env jquery */
-/* globals Swiper, sessionLengths, utils, pauseVideos, readyVideos */
+/* globals Swiper, sessionLengths, utils, pauseVideos */
 
 (function() {
     var highlightTocItem = function($toc, id) {
@@ -15,12 +15,10 @@
             onSlideNextStart: function(s) {
                 $(document).scrollTop(0);
                 pauseVideos($(s.slides[s.activeIndex - 1]));
-                readyVideos($(s.slides[s.activeIndex]));
             },
             onSlidePrevStart: function(s) {
                 $(document).scrollTop(0);
                 pauseVideos($(s.slides[s.activeIndex + 1]));
-                readyVideos($(s.slides[s.activeIndex]));
             },
             onSlideChangeEnd: function(s) {
                 highlightTocItem(


### PR DESCRIPTION
When preload is set to none, the readyVideos() behavior seems to be
interfering with the normal video loading behavior in the phonegap
applications on the lenovo and asus. desktop-chrome seems unaffected and
works well either way. This change makes the videos behave well
everywhere, as far as my testing has seen.